### PR TITLE
Typo in Utilities docs

### DIFF
--- a/docs/basics/Utilities.mdx
+++ b/docs/basics/Utilities.mdx
@@ -63,7 +63,7 @@ const RedBox = styled.div`
 `prop` lets you get a property from props, you can also specify a theme default.
 
 ```js
-import { styled, th } from '@smooth-ui/core-sc'
+import { styled, prop } from '@smooth-ui/core-sc'
 
 const RedBox = styled.div`
   width: 200px;


### PR DESCRIPTION
Quick fix in docs for `prop`