### PR TITLE
docs(typo): Fix bad package name

### DIFF
--- a/docs/GettingStarted.mdx
+++ b/docs/GettingStarted.mdx
@@ -34,7 +34,7 @@ export default App
 Even if it is not required, is recommended to apply a global normalize before using Smooth UI.
 
 ```js
-import { injectGlobal } from 'styled-component'
+import { injectGlobal } from 'styled-components'
 import { globalStyle } from '@smooth-ui/core-sc'
 
 injectGlobal`${globalStyle}`


### PR DESCRIPTION
Hi!

There is a typo on styled-components package name.