### PR TITLE
Fix documentation about globalStyle injection for styled-components & emotion

### DIFF
--- a/docs/GettingStarted.mdx
+++ b/docs/GettingStarted.mdx
@@ -37,7 +37,7 @@ Even if it is not required, is recommended to apply a global normalize before us
 import { injectGlobal } from 'styled-components'
 import { globalStyle } from '@smooth-ui/core-sc'
 
-injectGlobal`${globalStyle}`
+injectGlobal`${globalStyle()}`
 ```
 
 If you don't want to use a global normalize, at least add `* { box-sizing: border-box; }`.

--- a/docs/basics/Emotion.mdx
+++ b/docs/basics/Emotion.mdx
@@ -36,7 +36,7 @@ Even if it is not required, is recommended to apply a global normalize before us
 import { injectGlobal } from 'react-emotion'
 import { globalStyle } from '@smooth-ui/core-em'
 
-injectGlobal`${globalStyle}`
+injectGlobal`${globalStyle()}`
 ```
 
 If you don't want to use a global normalize, at least add `* { box-sizing: border-box; }`.


### PR DESCRIPTION
This PR fixes a small typo in the documentation that would prevent the `globalStyle` from being injected properly.