### PR TITLE
Updated reference of fontFamilyBase to fontFamily

### DIFF
--- a/docs/components/Typography.mdx
+++ b/docs/components/Typography.mdx
@@ -13,7 +13,7 @@ import { Typography } from '@smooth-ui/core-sc'
 
 All elements of Smooth UI have defaults font settings that you can override in theme:
 
-- `fontFamilyBase`: based on a [Native font stack](https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/)
+- `fontFamily`: based on a [Native font stack](https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/)
 - `fontSizeBase`: 1rem
 - `lineHeightBase`: 1.5
 


### PR DESCRIPTION
A really quick PR to improve the documentation and update a reference. It references `fontFamilyBase` but it should be `fontFamily`.