### PR TITLE
Remove value prop from Checkbox component example

### DIFF
--- a/docs/components/Checkbox.mdx
+++ b/docs/components/Checkbox.mdx
@@ -19,7 +19,6 @@ Set sizes using `size` prop like `"sm"`, `"md"` or `"lg"`.
       size="sm"
       id="sizeCheckbox1"
       name="sizeCheckboxs"
-      value="option1"
     />
     <FormCheckLabel htmlFor="sizeCheckbox1">Small</FormCheckLabel>
   </FormCheck>
@@ -32,7 +31,7 @@ Set sizes using `size` prop like `"sm"`, `"md"` or `"lg"`.
       size="lg"
       id="sizeCheckbox3"
       name="sizeCheckboxs"
-      value="option3"
+      checked={true}
     />
     <FormCheckLabel htmlFor="sizeCheckbox3">Large</FormCheckLabel>
   </FormCheck>
@@ -48,7 +47,6 @@ Disable using `disabled` prop.
       disabled
       id="disabledCheckbox1"
       name="disabledCheckboxs"
-      value="option1"
     />
     <FormCheckLabel htmlFor="disabledCheckbox1">Disabled</FormCheckLabel>
   </FormCheck>


### PR DESCRIPTION
As far as I can tell (https://github.com/smooth-code/smooth-ui/blob/master/packages/shared/core/Checkbox.js#L144-L150), value prop is irrelevant for the Checkbox component