### PR TITLE
Fix documentation typo

### DIFF
--- a/docs/basics/Utilities.mdx
+++ b/docs/basics/Utilities.mdx
@@ -14,7 +14,7 @@ Smooth UI exposes several utilities to simplify the styling of components.
 
 ### styled
 
-`styled` is exported from `@emotion/styled` if you use `@smooth-ui/core-sc` or from `styled-components` if you use `@smooth-ui/core-em`.
+`styled` is exported from `styled-components` if you use `@smooth-ui/core-sc` or from `@emotion/styled` if you use `@smooth-ui/core-em`.
 
 ```js
 import { styled } from '@smooth-ui/core-sc'


### PR DESCRIPTION
Just noticed that the docs have emotion/style-components the wrong way around with respect to where `styled` gets imported from.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes an inaccuracy in the the docs

## Test plan

n/a
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
