### PR TITLE
Use pointer cursor on FormCheckLabels

### DIFF
--- a/packages/shared/core/FormCheckLabel.js
+++ b/packages/shared/core/FormCheckLabel.js
@@ -7,10 +7,12 @@ const FormCheckLabel = createComponent(() => ({
   name: 'form-check-label',
   defaultComponent: 'label',
   style: p => css`
+    cursor: pointer;
     padding-left: 0.25rem;
 
     [class*='disabled'] ~ & {
       color: ${inputDisabledText(p)};
+      cursor: default;
     }
   `,
   propTypes: {


### PR DESCRIPTION
## Summary
Indicate that the label is clickable (unless it's disabled).

## Test plan
Hover the label in the checkbox (or radio) docs.

* Current: [checkbox demo](https://smooth-ui.smooth-code.com/docs-components-checkbox)
* Suggested: [checkbox demo](https://deploy-preview-116--smooth-ui.netlify.com/docs-components-checkbox)
