### PR TITLE
fix: fix toggle behavior

### DIFF
--- a/packages/core-em/.size-snapshot.json
+++ b/packages/core-em/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "/Users/neoziro/Projects/smooth-ui/packages/core-em/dist/smooth-ui-core-em.es.js": {
-    "bundled": 105657,
-    "minified": 72464,
-    "gzipped": 15505,
+    "bundled": 105664,
+    "minified": 72473,
+    "gzipped": 15509,
     "treeshaked": {
       "rollup": {
         "code": 495,
@@ -14,8 +14,8 @@
     }
   },
   "/Users/neoziro/Projects/smooth-ui/packages/core-em/dist/smooth-ui-core-em.cjs.js": {
-    "bundled": 112821,
-    "minified": 78916,
-    "gzipped": 16368
+    "bundled": 112828,
+    "minified": 78925,
+    "gzipped": 16373
   }
 }

--- a/packages/core-sc/.size-snapshot.json
+++ b/packages/core-sc/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "/Users/neoziro/Projects/smooth-ui/packages/core-sc/dist/smooth-ui-core-sc.es.js": {
-    "bundled": 84821,
-    "minified": 56448,
-    "gzipped": 13644,
+    "bundled": 84828,
+    "minified": 56457,
+    "gzipped": 13650,
     "treeshaked": {
       "rollup": {
         "code": 451,
@@ -14,8 +14,8 @@
     }
   },
   "/Users/neoziro/Projects/smooth-ui/packages/core-sc/dist/smooth-ui-core-sc.cjs.js": {
-    "bundled": 91587,
-    "minified": 62668,
-    "gzipped": 14446
+    "bundled": 91594,
+    "minified": 62677,
+    "gzipped": 14451
   }
 }

--- a/packages/shared/core/hooks/useToggle.js
+++ b/packages/shared/core/hooks/useToggle.js
@@ -8,7 +8,7 @@ export default function useToggle(defaultToggled = false, onToggle) {
   const toggle = useCallback(
     toggled =>
       setToggled(
-        toggled === undefined ? previousToggled => !previousToggled : toggled,
+        typeof toggled === 'boolean' ? toggled : previousToggled => !previousToggled
       ),
     [setToggled],
   )


### PR DESCRIPTION
This fixes the toggle behavior demonstrated in https://github.com/smooth-code/smooth-ui/issues/138.



## Summary

The `Toggler` component no longer worked when the `onToggle` function was passed directly to an onClick function. There are two ways to call onToggle:
```js
// Give an argument to toggle to
onToggle(true) // flip toggle to true
onToggle(true) // flip toggle to true

// Flip whatever the current toggle is
onToggle() // false -> true and true -> false
```

Before 10.x, the argument passed to `onToggle` was checked against the boolean type. After 10.x, it was just checked if it wasn't undefined. Normally this would be fine, but a common use case (including what was in the docs!) was to pass it directly on an onClick function:
```js
<button onClick={onToggle} />
```
Since the onClick functions pass an event as their argument, the first way to call `onToggle` was triggered instead of the second way.

## Test plan

I verified that this works by looking at the docs:

Before:
![smoothui before](https://user-images.githubusercontent.com/5108627/57934125-f30d4b00-788c-11e9-9d55-19f314c7ef7a.gif)

After:
![smoothui after](https://user-images.githubusercontent.com/5108627/57934137-f6a0d200-788c-11e9-9981-e76f3d56d5dc.gif)

